### PR TITLE
Add offline USCCB parser with sample fixture

### DIFF
--- a/fixtures/usccb/sample_1.html
+++ b/fixtures/usccb/sample_1.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<h3>Reading 1</h3>
+<p>Deuteronomy 6:4-13</p>
+<p>Moses said to the people:</p>
+<p>Hear, O Israel! The LORD is our God, the LORD alone!</p>
+
+<h3>Responsorial Psalm</h3>
+<p>Psalm 112:1-2, 3-4, 5-6</p>
+<p>Blessed the man who fears the LORD, who greatly delights in his commands.</p>
+<p>His posterity shall be mighty upon the earth.</p>
+
+<h3>Gospel</h3>
+<p>Matthew 24:42-51</p>
+<p>Jesus said to his disciples:</p>
+<p>Stay awake! For you do not know on which day your Lord will come.</p>
+</body>
+</html>

--- a/src/lectio_plus/parse.py
+++ b/src/lectio_plus/parse.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from html.parser import HTMLParser
+from typing import List
+
+
+@dataclass
+class Section:
+    label: str
+    citation: str
+    text: str
+    is_psalm: bool
+    is_gospel: bool
+
+
+class _TextExtractor(HTMLParser):
+    """Simple HTML text extractor.
+
+    Collects all text nodes in the order encountered. Each piece of
+    significant text becomes a separate entry in ``texts``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.texts: List[str] = []
+
+    def handle_data(self, data: str) -> None:
+        text = data.strip()
+        if text:
+            self.texts.append(text)
+
+
+_READING_RE = re.compile(r"reading\s+[0-9ivxlcdm]+", re.IGNORECASE)
+
+
+def _is_heading(text: str) -> bool:
+    lt = text.strip().lower()
+    return bool(_READING_RE.fullmatch(lt)) or lt in {"responsorial psalm", "gospel"}
+
+
+def _looks_like_citation(text: str) -> bool:
+    return ":" in text and bool(re.search(r"\d", text))
+
+
+def extract_sections(html: str) -> List[Section]:
+    parser = _TextExtractor()
+    parser.feed(html)
+    lines = parser.texts
+
+    sections: List[Section] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if _is_heading(line):
+            label = line
+            lower = label.lower()
+            is_psalm = lower == "responsorial psalm"
+            is_gospel = lower == "gospel"
+            i += 1
+            citation = ""
+            if i < len(lines) and _looks_like_citation(lines[i]):
+                citation = lines[i]
+                i += 1
+            body_lines: List[str] = []
+            while i < len(lines) and not _is_heading(lines[i]):
+                body_lines.append(lines[i])
+                i += 1
+            text = "\n".join(body_lines).strip()
+            sections.append(
+                Section(
+                    label=label,
+                    citation=citation,
+                    text=text,
+                    is_psalm=is_psalm,
+                    is_gospel=is_gospel,
+                )
+            )
+        else:
+            i += 1
+    return sections
+
+
+def build_readings_block(sections: List[Section]) -> str:
+    blocks: List[str] = []
+    for sec in sections:
+        lines = [sec.label]
+        if sec.citation:
+            lines.append(sec.citation)
+        if sec.text:
+            lines.append(sec.text.strip())
+        blocks.append("\n".join(lines))
+    return "\n\n".join(blocks)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+
+# Ensure src package is importable
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+from lectio_plus.parse import extract_sections, build_readings_block
+
+
+def read_fixture(name: str) -> str:
+    path = Path(__file__).resolve().parents[1] / 'fixtures' / 'usccb' / name
+    return path.read_text(encoding='utf-8')
+
+
+def test_extract_sections_basic():
+    html = read_fixture('sample_1.html')
+    sections = extract_sections(html)
+
+    reading_sections = [s for s in sections if s.label.lower().startswith('reading')]
+    psalm_sections = [s for s in sections if s.is_psalm]
+    gospel_sections = [s for s in sections if s.is_gospel]
+
+    assert len(reading_sections) == 1
+    assert len(psalm_sections) == 1
+    assert len(gospel_sections) == 1
+
+    for sec in sections:
+        assert sec.citation  # citation present
+
+    assert psalm_sections[0].is_psalm and not psalm_sections[0].is_gospel
+    assert gospel_sections[0].is_gospel and not gospel_sections[0].is_psalm
+
+
+def test_build_readings_block_contains_sections():
+    html = read_fixture('sample_1.html')
+    sections = extract_sections(html)
+    block = build_readings_block(sections)
+
+    for sec in sections:
+        assert sec.label in block
+        assert sec.text.split('\n')[0] in block


### PR DESCRIPTION
## Summary
- implement Section dataclass and HTML parsing helpers
- add build_readings_block to join parsed sections
- provide offline USCCB HTML fixture and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897a97c2e38832097c8748feb1eee0a