### PR TITLE
Add project scaffolding and smoke test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+Python 3.11
+
+Install: pip install -r requirements.txt
+
+Lint: ruff check .
+
+Type-check: mypy src
+
+Tests: pytest -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "gippity"
+version = "0.1.0"
+requires-python = ">=3.11"
+
+[tool.ruff]
+line-length = 88
+
+[tool.mypy]
+python_version = "3.11"
+check_untyped_defs = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pytest
+ruff
+mypy

--- a/src/pkg/__init__.py
+++ b/src/pkg/__init__.py
@@ -1,0 +1,4 @@
+"""pkg package."""
+
+def hello() -> str:
+    return "hello"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from pkg import hello
+
+
+def test_smoke() -> None:
+    assert hello() == "hello"


### PR DESCRIPTION
## Summary
- document Python 3.11 workflow in `AGENTS.md`
- configure ruff, mypy and dependencies via `pyproject.toml` and `requirements.txt`
- add `pkg.hello` and a smoke test

## Testing
- `python -V`
  ```
  Python 3.11.12
  ```
- `pip install -r requirements.txt`
  ```
  Requirement already satisfied: pytest in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (from -r requirements.txt (line 1)) (8.4.1)
  Requirement already satisfied: ruff in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (from -r requirements.txt (line 2)) (0.12.7)
  Requirement already satisfied: mypy in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (from -r requirements.txt (line 3)) (1.17.1)
  ```
- `ruff check .`
  ```
  All checks passed!
  ```
- `mypy src`
  ```
  Success: no issues found in 1 source file
  ```
- `pytest -q`
  ```
  .
  1 passed in 0.01s
  ```

------
https://chatgpt.com/codex/tasks/task_e_6897a4d01df08320ba4842fdb1a4074a