### PR TITLE
Scaffold lectio_plus package with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # gippity
+
+## Quickstart
+
+1. Install dependencies: `pip install -r requirements.txt`
+2. Run the linters: `ruff check .`
+3. Run the type checker: `mypy src`
+4. Run the tests: `pytest -q`
+
+## Package layout
+
+```
+src/
+└── lectio_plus/
+    ├── __init__.py
+    ├── app.py
+    ├── cache.py
+    ├── curator.py
+    ├── html_build.py
+    ├── parse.py
+    ├── prompts.py
+    └── scrape.py
+```

--- a/fixtures/usccb/sample_1.html
+++ b/fixtures/usccb/sample_1.html
@@ -1,0 +1,1 @@
+<html><body>Sample 1</body></html>

--- a/src/lectio_plus/__init__.py
+++ b/src/lectio_plus/__init__.py
@@ -1,0 +1,5 @@
+"""Top level package for :mod:`lectio_plus`."""
+
+from .app import run
+
+__all__ = ["run"]

--- a/src/lectio_plus/app.py
+++ b/src/lectio_plus/app.py
@@ -1,0 +1,11 @@
+"""Application entry points for :mod:`lectio_plus`."""
+
+from .html_build import build_html
+
+
+def run(text: str) -> str:
+    """Return a simple HTML page containing ``text``."""
+    return build_html(text)
+
+
+__all__ = ["run"]

--- a/src/lectio_plus/cache.py
+++ b/src/lectio_plus/cache.py
@@ -1,0 +1,21 @@
+"""A tiny in-memory cache."""
+
+from typing import Any
+
+
+class SimpleCache:
+    """A minimal cache storing values in a dictionary."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, Any] = {}
+
+    def get(self, key: str) -> Any | None:
+        """Retrieve a cached value."""
+        return self._store.get(key)
+
+    def set(self, key: str, value: Any) -> None:
+        """Store ``value`` under ``key``."""
+        self._store[key] = value
+
+
+__all__ = ["SimpleCache"]

--- a/src/lectio_plus/curator.py
+++ b/src/lectio_plus/curator.py
@@ -1,0 +1,11 @@
+"""Content curation helpers."""
+
+from collections.abc import Iterable
+
+
+def curate(parts: Iterable[str]) -> str:
+    """Join ``parts`` with newlines."""
+    return "\n".join(parts)
+
+
+__all__ = ["curate"]

--- a/src/lectio_plus/html_build.py
+++ b/src/lectio_plus/html_build.py
@@ -1,0 +1,9 @@
+"""HTML building helpers."""
+
+
+def build_html(body: str) -> str:
+    """Wrap ``body`` in a minimal HTML page."""
+    return f"<html><body>{body}</body></html>"
+
+
+__all__ = ["build_html"]

--- a/src/lectio_plus/parse.py
+++ b/src/lectio_plus/parse.py
@@ -1,0 +1,13 @@
+"""Parsing helpers for :mod:`lectio_plus`."""
+
+
+def parse_usccb_html(html: str) -> str:
+    """Return the raw ``html`` for now.
+
+    The real project would parse the input, but the placeholder simply returns
+    it unchanged.
+    """
+    return html
+
+
+__all__ = ["parse_usccb_html"]

--- a/src/lectio_plus/prompts.py
+++ b/src/lectio_plus/prompts.py
@@ -1,0 +1,5 @@
+"""Prompt definitions for :mod:`lectio_plus`."""
+
+BASE_PROMPT = "Summarize the supplied text."
+
+__all__ = ["BASE_PROMPT"]

--- a/src/lectio_plus/scrape.py
+++ b/src/lectio_plus/scrape.py
@@ -1,0 +1,9 @@
+"""Scraping utilities."""
+
+
+def fetch(url: str) -> str:
+    """Return placeholder data for ``url``."""
+    return f"data from {url}"
+
+
+__all__ = ["fetch"]

--- a/tests/test_app_smoke.py
+++ b/tests/test_app_smoke.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from lectio_plus.app import run
+
+
+def test_app_run_returns_html() -> None:
+    html = run("Hi")
+    assert html.startswith("<html>")
+    assert html.endswith("</html>")

--- a/tests/test_curator.py
+++ b/tests/test_curator.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from lectio_plus.curator import curate
+
+
+def test_curate_joins_parts() -> None:
+    result = curate(["a", "b"])
+    assert result == "a\nb"

--- a/tests/test_html_build.py
+++ b/tests/test_html_build.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from lectio_plus.html_build import build_html
+
+
+def test_build_html_wraps_body() -> None:
+    html = build_html("Hello")
+    assert "<body>Hello</body>" in html

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from lectio_plus.parse import parse_usccb_html
+
+
+def test_parse_sample() -> None:
+    sample = Path("fixtures/usccb/sample_1.html").read_text()
+    result = parse_usccb_html(sample)
+    assert "Sample 1" in result

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from lectio_plus.prompts import BASE_PROMPT
+
+
+def test_base_prompt_defined() -> None:
+    assert isinstance(BASE_PROMPT, str)
+    assert BASE_PROMPT


### PR DESCRIPTION
## Summary
- add placeholder `lectio_plus` package modules and HTML fixture
- provide basic tests for parsing, curation, prompts, HTML building, and app smoke run
- document quickstart commands and package layout in README

## Testing
- `python -m pip install -r requirements.txt`
- `ruff check .`
- `mypy src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897bb3996bc8320b96c2e6ed914abe7