### PR TITLE
Implement USCCB HTML parsing

### DIFF
--- a/fixtures/usccb/sample_1.html
+++ b/fixtures/usccb/sample_1.html
@@ -1,1 +1,19 @@
-<html><body>Sample 1</body></html>
+<html>
+  <body>
+    <h2>Reading 1</h2>
+    <p>Deuteronomy 6:4-13</p>
+    <p>Moses said to the people:</p>
+    <p>"Hear, O Israel!"</p>
+
+    <h2>Responsorial Psalm</h2>
+    <p>Psalm 18:2-3, 3-4, 47 and 51</p>
+    <p>I love you, Lord, my strength.</p>
+    <p>My rock, my fortress, my deliverer.</p>
+
+    <h2>Gospel</h2>
+    <p>Matthew 17:14-20</p>
+    <p>Jesus said to his disciples:</p>
+    <p>"Amen, I say to you..."</p>
+  </body>
+</html>
+

--- a/src/lectio_plus/parse.py
+++ b/src/lectio_plus/parse.py
@@ -1,13 +1,126 @@
-"""Parsing helpers for :mod:`lectio_plus`."""
+"""Parsing helpers for :mod:`lectio_plus`.
+
+This module provides lightweight parsing utilities tailored for small HTML
+snippets from the USCCB web site.  It intentionally avoids external
+dependencies so the implementation can operate on the provided fixtures
+without network access.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import List
+
+
+@dataclass
+class Section:
+    """Represents one liturgical section from the USCCB readings page."""
+
+    label: str
+    citation: str
+    text: str
+    is_psalm: bool
+    is_gospel: bool
+
+
+_HEADING_RE = re.compile(
+    r"^(reading\s*[1i]|responsorial psalm|gospel)", re.IGNORECASE
+)
+
+
+def _html_to_lines(html: str) -> List[str]:
+    """Return a list of textual lines extracted from ``html``."""
+
+    # Normalize a few block-level tags into newlines so we can work with plain
+    # text.  This is *very* small‑scale and only needs to support our fixture.
+    text = re.sub(r"(?i)<br\s*/?>", "\n", html)
+    text = re.sub(r"(?i)</(p|div|h[1-6])>", "\n", text)
+    text = re.sub(r"<[^>]+>", "", text)
+    lines = [line.strip() for line in text.splitlines()]
+    return [line for line in lines if line]
+
+
+def _looks_like_citation(line: str) -> bool:
+    """Return ``True`` if ``line`` resembles a scripture citation."""
+
+    return bool(re.search(r"\d+:\d+", line))
+
+
+def extract_sections(html: str) -> List[Section]:
+    """Extract :class:`Section` objects from ``html``.
+
+    The parser searches for headings such as ``Reading 1``, ``Responsorial
+    Psalm`` and ``Gospel``.  The first scripture‑looking line after a heading is
+    treated as the citation and the remaining lines up to the next heading make
+    up the body of the section.
+    """
+
+    lines = _html_to_lines(html)
+    sections: List[Section] = []
+    current: Section | None = None
+    body_lines: List[str] = []
+    expecting_citation = False
+
+    for line in lines:
+        lower = line.lower()
+        if _HEADING_RE.match(lower):
+            # Close out the previous section if we were building one.
+            if current is not None:
+                current.text = "\n".join(body_lines).strip()
+                sections.append(current)
+
+            is_psalm = lower.startswith("responsorial psalm")
+            is_gospel = lower.startswith("gospel")
+            current = Section(line, "", "", is_psalm, is_gospel)
+            body_lines = []
+            expecting_citation = True
+            continue
+
+        if current is not None:
+            if expecting_citation:
+                # The first non-heading line is assumed to be a citation.  If it
+                # does not look like a citation, we still treat it as one.
+                if _looks_like_citation(line) or not current.citation:
+                    current.citation = line
+                    expecting_citation = False
+                    continue
+
+            body_lines.append(line)
+
+    if current is not None:
+        current.text = "\n".join(body_lines).strip()
+        sections.append(current)
+
+    return sections
+
+
+def build_readings_block(sections: List[Section]) -> str:
+    """Build a single string containing all sections in order."""
+
+    blocks = []
+    for sec in sections:
+        lines = [sec.label]
+        if sec.citation:
+            lines.append(sec.citation)
+        if sec.text:
+            lines.append(sec.text)
+        blocks.append("\n".join(lines))
+
+    return "\n\n".join(blocks).strip()
 
 
 def parse_usccb_html(html: str) -> str:
-    """Return the raw ``html`` for now.
+    """Parse ``html`` and return a human readable readings block."""
 
-    The real project would parse the input, but the placeholder simply returns
-    it unchanged.
-    """
-    return html
+    sections = extract_sections(html)
+    return build_readings_block(sections)
 
 
-__all__ = ["parse_usccb_html"]
+__all__ = [
+    "parse_usccb_html",
+    "Section",
+    "extract_sections",
+    "build_readings_block",
+]
+

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -3,10 +3,35 @@ import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-from lectio_plus.parse import parse_usccb_html
+from lectio_plus.parse import build_readings_block, extract_sections
 
 
-def test_parse_sample() -> None:
-    sample = Path("fixtures/usccb/sample_1.html").read_text()
-    result = parse_usccb_html(sample)
-    assert "Sample 1" in result
+def test_extract_and_build() -> None:
+    html = Path("fixtures/usccb/sample_1.html").read_text()
+    sections = extract_sections(html)
+
+    readings = [s for s in sections if s.label.lower().startswith("reading")]
+    psalms = [s for s in sections if s.is_psalm]
+    gospels = [s for s in sections if s.is_gospel]
+
+    assert len(readings) == 1
+    assert len(psalms) == 1
+    assert len(gospels) == 1
+
+    reading = readings[0]
+    psalm = psalms[0]
+    gospel = gospels[0]
+
+    assert reading.citation == "Deuteronomy 6:4-13"
+    assert psalm.citation == "Psalm 18:2-3, 3-4, 47 and 51"
+    assert gospel.citation == "Matthew 17:14-20"
+
+    assert not reading.is_psalm and not reading.is_gospel
+    assert psalm.is_psalm and not psalm.is_gospel
+    assert gospel.is_gospel and not gospel.is_psalm
+
+    block = build_readings_block(sections)
+    for section in (reading, psalm, gospel):
+        assert section.label in block
+        assert section.text in block
+


### PR DESCRIPTION
## Summary
- add `Section` dataclass and helpers to extract USCCB readings from HTML
- provide sample USCCB HTML fixture
- test parsing and block building for reading, psalm, and gospel

## Testing
- `ruff check .`
- `mypy src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897bc65bf6c832087ef365c2f848a74