### PR TITLE
Add templated prompts and helpers

### DIFF
--- a/src/lectio_plus/prompts.py
+++ b/src/lectio_plus/prompts.py
@@ -1,5 +1,75 @@
-"""Prompt definitions for :mod:`lectio_plus`."""
+"""Prompt definitions for :mod:`lectio_plus`.
 
-BASE_PROMPT = "Summarize the supplied text."
+This module centralizes all template strings used by the lectio-plus
+application.  Each template contains placeholders that are filled by the
+helper functions defined below.
+"""
 
-__all__ = ["BASE_PROMPT"]
+from __future__ import annotations
+
+
+PROMPT_1 = (
+    "CATHOLIC DAILY LECTIO-PLUS MODULE\n"
+    "Use the following lectionary readings as the basis for a brief, clear "
+    "reflection.\n\n"
+    "<<READINGS>>"
+)
+
+
+PROMPT_2 = (
+    "You are an art curator who responds strictly in JSON.\n"
+    "Given the date <<DATE>> and the scripture passages below, suggest "
+    "relevant works of art.  Return a JSON array where each item has the "
+    "keys 'title', 'artist', 'year', and 'reason'.  Do not include any extra "
+    "fields or commentary.\n\n"
+    "<<READINGS>>"
+)
+
+
+PROMPT_3 = (
+    "Build an HTML fragment for a daily lectio page.\n"
+    "Insert the date in an <h1> element and arrange the provided blocks in "
+    "separate <section> elements.\n\n"
+    "Date: <<DATE>>\n"
+    "Blocks:\n"
+    "<<RAW_BLOCKS>>"
+)
+
+
+def make_prompt1(readings_block: str) -> str:
+    """Insert ``readings_block`` into :data:`PROMPT_1`."""
+
+    return PROMPT_1.replace("<<READINGS>>", readings_block)
+
+
+def make_prompt2(date_str: str, readings_block: str) -> str:
+    """Insert ``date_str`` and truncated ``readings_block`` into
+    :data:`PROMPT_2`.
+
+    The ``readings_block`` is truncated to 8,000 characters to keep the
+    resulting prompt at a manageable size.
+    """
+
+    truncated = readings_block[:8000]
+    return (
+        PROMPT_2.replace("<<DATE>>", date_str).replace("<<READINGS>>", truncated)
+    )
+
+
+def make_prompt3(date_str: str, raw_blocks: str) -> str:
+    """Insert ``date_str`` and ``raw_blocks`` into :data:`PROMPT_3`."""
+
+    return (
+        PROMPT_3.replace("<<DATE>>", date_str).replace("<<RAW_BLOCKS>>", raw_blocks)
+    )
+
+
+__all__ = [
+    "PROMPT_1",
+    "PROMPT_2",
+    "PROMPT_3",
+    "make_prompt1",
+    "make_prompt2",
+    "make_prompt3",
+]
+

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,11 +1,55 @@
+"""Tests for :mod:`lectio_plus.prompts`."""
+
 from pathlib import Path
 import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-from lectio_plus.prompts import BASE_PROMPT
+from lectio_plus.prompts import (  # noqa: E402  (import after sys.path tweak)
+    PROMPT_1,
+    PROMPT_2,
+    PROMPT_3,
+    make_prompt1,
+    make_prompt2,
+    make_prompt3,
+)
 
 
-def test_base_prompt_defined() -> None:
-    assert isinstance(BASE_PROMPT, str)
-    assert BASE_PROMPT
+def test_make_prompt1_inserts_readings() -> None:
+    block = "First reading"
+    result = make_prompt1(block)
+    assert block in result
+    assert "<<READINGS>>" not in result
+
+
+def test_prompts_defined() -> None:
+    assert isinstance(PROMPT_1, str) and PROMPT_1
+    assert isinstance(PROMPT_2, str) and PROMPT_2
+    assert isinstance(PROMPT_3, str) and PROMPT_3
+
+
+def test_make_prompt2_truncates_and_fills() -> None:
+    long_text = "R" * 9000
+    date_str = "2024-05-18"
+    result = make_prompt2(date_str, long_text)
+    assert date_str in result
+    assert "<<DATE>>" not in result
+    assert "<<READINGS>>" not in result
+    assert "R" * 8000 in result
+    assert "R" * 8001 not in result
+
+
+def test_make_prompt3_inserts_blocks() -> None:
+    date_str = "2024-05-18"
+    blocks = "<p>Content</p>"
+    result = make_prompt3(date_str, blocks)
+    assert date_str in result
+    assert blocks in result
+    assert "<<DATE>>" not in result
+    assert "<<RAW_BLOCKS>>" not in result
+
+
+def test_no_smart_apostrophe() -> None:
+    text = Path("src/lectio_plus/prompts.py").read_text(encoding="utf-8")
+    assert "\u2019" not in text
+


### PR DESCRIPTION
## Summary
- introduce three prompt templates for readings, art curation JSON, and HTML layout
- add helper functions to populate templates and enforce 8k reading truncation
- expand tests for prompt filling, truncation, and smart-apostrophe check

## Testing
- `python -m pip install -r requirements.txt`
- `ruff check .`
- `mypy src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897cd1a5a10832088f4ea44128ae4a0