### PR TITLE
Add LLM provider switch and strict art JSON parsing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# LLM provider configuration
+# LLM_PROVIDER=ollama
+# OPENAI_BASE_URL=http://localhost:11434/v1
+# OPENAI_API_KEY=ollama
+# REFLECTION_MODEL=deepseek-r1:14b
+# ART_MODEL=mistral:latest
+# HTML_MODEL=mistral:latest

--- a/README.md
+++ b/README.md
@@ -21,3 +21,24 @@ src/
     ├── prompts.py
     └── scrape.py
 ```
+
+## LLM providers
+
+Offline (default):
+
+```
+LLM_PROVIDER not set → FakeLLM
+```
+
+Ollama:
+
+```
+export LLM_PROVIDER=ollama
+export OPENAI_BASE_URL=http://localhost:11434/v1
+export OPENAI_API_KEY=ollama
+export REFLECTION_MODEL=deepseek-r1:14b
+export ART_MODEL=mistral:latest
+export HTML_MODEL=mistral:latest
+
+python -m lectio_plus.app --serve
+```

--- a/src/lectio_plus/app.py
+++ b/src/lectio_plus/app.py
@@ -1,11 +1,112 @@
-"""Application entry points for :mod:`lectio_plus`."""
+"""Application entry points and LLM provider selection for :mod:`lectio_plus`."""
 
+from __future__ import annotations
+
+import os
+from typing import Protocol
+
+from . import prompts
+from .curator import curate, parse_art_json
 from .html_build import build_html
 
 
-def run(text: str) -> str:
-    """Return a simple HTML page containing ``text``."""
-    return build_html(text)
+class LLM(Protocol):
+    """Minimal interface implemented by language model providers."""
+
+    def generate(
+        self,
+        model: str,
+        prompt: str,
+        temperature: float = 0.2,
+        max_tokens: int | None = None,
+    ) -> str:
+        """Return a completion for ``prompt``."""
 
 
-__all__ = ["run"]
+class FakeLLM:
+    """Offline stand‑in returning canned responses for the three prompts."""
+
+    def generate(
+        self,
+        model: str,
+        prompt: str,
+        temperature: float = 0.2,
+        max_tokens: int | None = None,
+    ) -> str:
+        if "Build an HTML fragment" in prompt:
+            return "<section>stub html</section>"
+        if "art curator" in prompt:
+            return (
+                "{\"title\": \"Test Art\", \"artist\": \"Anon\", "
+                "\"year\": \"1900\", \"image_url\": "
+                "\"https://upload.wikimedia.org/test.jpg\"}"
+            )
+        return "stub reflection"
+
+
+class OpenAILLM:
+    """Thin wrapper around the official OpenAI Python SDK."""
+
+    def __init__(self, base_url: str | None, api_key: str) -> None:
+        self._base_url = base_url
+        self._api_key = api_key
+
+    def generate(
+        self,
+        model: str,
+        prompt: str,
+        temperature: float = 0.2,
+        max_tokens: int | None = None,
+    ) -> str:
+        from openai import OpenAI  # type: ignore[import-not-found]
+
+        client = OpenAI(
+            base_url=self._base_url,
+            api_key=self._api_key,
+            timeout=10.0,
+        )
+        resp = client.responses.create(
+            model=model,
+            input=prompt,
+            temperature=temperature,
+            max_output_tokens=max_tokens,
+        )
+        return resp.output_text
+
+
+def get_llm() -> LLM:
+    """Return an :class:`LLM` implementation based on environment variables."""
+
+    provider = os.environ.get("LLM_PROVIDER")
+    if provider == "ollama":
+        base_url = os.environ.get("OPENAI_BASE_URL")
+        api_key = os.environ.get("OPENAI_API_KEY", "")
+        if base_url != "http://localhost:11434/v1" or not api_key:
+            raise RuntimeError("OLLAMA requires OPENAI_BASE_URL and OPENAI_API_KEY")
+        return OpenAILLM(base_url, api_key)
+    return FakeLLM()
+
+
+def run(readings_block: str) -> str:
+    """Generate HTML for ``readings_block`` using the configured LLM provider."""
+
+    llm = get_llm()
+    reflection_model = os.environ.get("REFLECTION_MODEL", "gpt-5-chat-latest")
+    art_model = os.environ.get("ART_MODEL", "gpt-5-mini")
+    html_model = os.environ.get("HTML_MODEL", "gpt-5-mini")
+
+    prompt1 = prompts.make_prompt1(readings_block)
+    reflection = llm.generate(reflection_model, prompt1)
+
+    prompt2 = prompts.make_prompt2("DATE", readings_block)
+    art_raw = llm.generate(art_model, prompt2)
+    art = parse_art_json(art_raw)
+    art_block = curate([art["title"], art["artist"], art["year"], art["image_url"]])
+
+    raw_blocks = curate([reflection, art_block])
+    prompt3 = prompts.make_prompt3("DATE", raw_blocks)
+    injected_html = llm.generate(html_model, prompt3)
+    return build_html(injected_html)
+
+
+__all__ = ["LLM", "FakeLLM", "OpenAILLM", "get_llm", "run"]

--- a/tests/test_app_smoke.py
+++ b/tests/test_app_smoke.py
@@ -3,10 +3,48 @@ import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-from lectio_plus.app import run
+import os
+
+from lectio_plus.app import FakeLLM, OpenAILLM, run
 
 
 def test_app_run_returns_html() -> None:
     html = run("Hi")
     assert html.startswith("<html>")
     assert html.endswith("</html>")
+
+
+def test_default_provider_uses_fake_llm(monkeypatch) -> None:
+    outputs = [
+        "reflection",
+        '{"title": "T", "artist": "A", "year": "2000", "image_url": "https://upload.wikimedia.org/x.jpg"}',
+        "<p>done</p>",
+    ]
+
+    def fake_generate(self, model, prompt, temperature=0.2, max_tokens=None):
+        return outputs.pop(0)
+
+    monkeypatch.setattr(FakeLLM, "generate", fake_generate)
+    os.environ.pop("LLM_PROVIDER", None)
+    html = run("block")
+    assert "<p>done</p>" in html
+    assert "<<" not in html and ">>" not in html
+
+
+def test_ollama_provider(monkeypatch) -> None:
+    outputs = [
+        "reflection",
+        '{"title": "T", "artist": "A", "year": "2000", "image_url": "https://upload.wikimedia.org/x.jpg"}',
+        "<p>done</p>",
+    ]
+
+    def fake_generate(self, model, prompt, temperature=0.2, max_tokens=None):
+        return outputs.pop(0)
+
+    monkeypatch.setattr(OpenAILLM, "generate", fake_generate)
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:11434/v1")
+    monkeypatch.setenv("OPENAI_API_KEY", "ollama")
+
+    html = run("block")
+    assert "<p>done</p>" in html

--- a/tests/test_curator.py
+++ b/tests/test_curator.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import importlib
 import sys
 
+import pytest
 import requests
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
@@ -77,4 +78,22 @@ def test_ensure_upload_wikimedia_url_uses_real_requests() -> None:
     real_requests = importlib.import_module("requests")
     assert curator.requests is real_requests
     assert "site-packages" in Path(real_requests.__file__).parts
+
+
+def test_parse_art_json_validation() -> None:
+    good = (
+        '{"title": "T", "artist": "A", "year": "1", '
+        '"image_url": "https://upload.wikimedia.org/x.jpg"}'
+    )
+    assert curator.parse_art_json(good)["title"] == "T"
+
+    bad_texts = [
+        "not json",
+        '{"title": "", "artist": "A", "year": "1", "image_url": "https://upload.wikimedia.org/x.jpg"}',
+        '{"title": "T", "artist": "A", "year": "1", "image_url": "https://example.com/x.jpg"}',
+        '{"title": "T", "artist": "A"}',
+    ]
+    for bad in bad_texts:
+        with pytest.raises(ValueError):
+            curator.parse_art_json(bad)
 


### PR DESCRIPTION
## Summary
- implement `LLM` interface with `FakeLLM` and OpenAI-backed provider selectable via env vars
- parse and validate art JSON with Wikimedia URL checks
- document LLM provider env vars and add example `.env`

## Testing
- `ruff check .`
- `mypy src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897cec7c16c83208ecd8ce93f4f448c