### PR TITLE
Use chat completions for Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,6 @@ python -m lectio_plus.app --serve
 Tests run entirely offline and do not require network access.  The
 `LLM_PROVIDER`, `OPENAI_BASE_URL` and `OPENAI_API_KEY` variables are optional
 and only needed when experimenting with Ollama.
+
+Ollama uses the OpenAI-compatible Chat Completions API while the OpenAI cloud
+provider uses the Responses API.

--- a/tests/test_app_smoke.py
+++ b/tests/test_app_smoke.py
@@ -31,7 +31,7 @@ def test_default_provider_uses_fake_llm(monkeypatch) -> None:
     assert "<<" not in html and ">>" not in html
 
 
-def test_ollama_provider(monkeypatch) -> None:
+def test_ollama_provider_offline(monkeypatch) -> None:
     outputs = [
         "reflection",
         '{"title": "T", "artist": "A", "year": "2000", "image_url": "https://upload.wikimedia.org/x.jpg"}',
@@ -72,6 +72,7 @@ def test_post_run_injects_metadata(monkeypatch) -> None:
     client = app.test_client()
     resp = client.post("/run", data={"date": "2024-05-04"})
     html = resp.get_data(as_text=True)
+    assert resp.headers["Content-Type"] == "text/html; charset=utf-8"
     assert "Current Date" not in html
     assert "Cover Title" not in html
     assert "Cover Artist" not in html


### PR DESCRIPTION
## Summary
- Add Ollama detection in OpenAILLM and route Chat Completions through `chat.completions.create`
- Return HTML with an explicit content type header from the `/run` route
- Document that Ollama uses Chat Completions while OpenAI cloud uses the Responses API

## Testing
- `ruff check .`
- `mypy src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897da615bfc8320b4e28d5d44ae3399