### PR TITLE
Fix mypy issue for OpenAI chat completion call

### DIFF
--- a/src/lectio_plus/app.py
+++ b/src/lectio_plus/app.py
@@ -81,18 +81,19 @@ class OpenAILLM:
         )
 
         if is_ollama:
+            msgs = [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": prompt},
+            ]
             kwargs: dict[str, object] = {
                 "model": model,
-                "messages": [
-                    {"role": "system", "content": "You are a helpful assistant."},
-                    {"role": "user", "content": prompt},
-                ],
+                "messages": msgs,
                 "temperature": temperature,
             }
             if max_tokens is not None:
                 kwargs["max_tokens"] = max_tokens
             resp = client.chat.completions.create(**kwargs)
-            return resp.choices[0].message.content
+            return resp.choices[0].message.content or ""
 
         resp = client.responses.create(
             model=model,


### PR DESCRIPTION
## Summary
- Fix mypy issue in Ollama path by passing OpenAI chat completion parameters as kwargs and ensuring a string return

## Testing
- `ruff check .`
- `mypy src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897e19234f48320a75d31af10223de4