### PR TITLE
Add unified local check script and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: check lint type test
+
+check:
+	scripts/check.sh
+
+lint:
+	python -m ruff check .
+
+type:
+	python -m mypy src
+
+test:
+	python -m pytest -q

--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@
 ## Quickstart
 
 1. Install dependencies: `pip install -r requirements.txt`
-2. Run the linters: `ruff check .`
-3. Run the type checker: `mypy src`
-4. Run the tests: `pytest -q`
-5. Start the web server: `python -m lectio_plus.app --serve`
+2. Run all checks: `make check`
+   - Or individually: `make lint`, `make type`, `make test`
+3. Start the web server: `python -m lectio_plus.app --serve`
 
 ## Package layout
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure we run from the repository root
+cd "$(dirname "$0")/.."
+
+# Unset provider environment variables to force offline mode
+env_vars=(LLM_PROVIDER OPENAI_BASE_URL OPENAI_API_KEY REFLECTION_MODEL ART_MODEL HTML_MODEL)
+for var in "${env_vars[@]}"; do
+  unset "$var" || true
+done
+
+python -m ruff check .
+python -m mypy src
+python -m pytest -q


### PR DESCRIPTION
## Summary
- add `scripts/check.sh` to run ruff, mypy, and pytest in an offline-safe environment
- provide `check`, `lint`, `type`, and `test` targets in a new Makefile
- document running `make check` and individual `make lint/type/test` commands in the README

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6897e56f8fd483209bae1c8737a36dbc