### PR TITLE
chore: add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.2
+    hooks:
+      - id: ruff
+        types: [python]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+        files: ^src/
+        language: system

--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 ## Quickstart
 
 1. Install dependencies: `pip install -r requirements.txt`
-2. Run all checks: `make check`
+2. Install pre-commit: `pip install pre-commit`
+3. Install git hooks: `pre-commit install`
+4. Run all checks: `make check`
    - Or individually: `make lint`, `make type`, `make test`
-3. Start the web server: `python -m lectio_plus.app --serve`
+5. Start the web server: `python -m lectio_plus.app --serve`
 
 ## Package layout
 


### PR DESCRIPTION
## Summary
- lint python code with ruff via pre-commit
- type-check staged files in src/ with mypy using system python
- document installing and enabling pre-commit hooks

## Testing
- `ruff check .`
- `mypy src`
- `pytest -q`
- `pre-commit run --files README.md src/lectio_plus/app.py` *(fails: command not found)
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit; No matching distribution found for pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_6897ea9a30148320a6a5c3efb17ac61a