### PR TITLE
feat: Prompt-3 deterministic layout + PDF export + download button

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ requests
 flask
 Flask
 openai
+pdfkit
+weasyprint

--- a/src/lectio_plus/curator.py
+++ b/src/lectio_plus/curator.py
@@ -60,6 +60,10 @@ def safe_parse_art_json(text: str) -> dict[str, str]:
     obj_text = match.group(0)
 
     data = json.loads(obj_text)
+    if isinstance(data, list):
+        data = next((item for item in data if isinstance(item, dict)), None)
+        if data is None:
+            raise ValueError("no object in list")
     required = ["title", "artist", "year", "image_url"]
     out: dict[str, str] = {}
     for key in required:

--- a/src/lectio_plus/html_build.py
+++ b/src/lectio_plus/html_build.py
@@ -1,4 +1,44 @@
-"""HTML building helpers."""
+"""HTML building helpers and deterministic Prompt-3 layout builder."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import html
+import re
+
+
+@dataclass
+class Section:
+    """Prompt-3 logical section for the booklet layout."""
+
+    heading: str
+    reading: str
+    context: str | None = None
+    exegesis: str | None = None
+    questions: list[str] | None = None
+
+
+def strip_code_fences(text: str) -> str:
+    """Remove code fences and common wrappers from model output.
+
+    Strips leading and trailing triple backticks and any language info, as well
+    as leading phrases like "Here is" / "Here are" that sometimes wrap content.
+    """
+
+    if not text:
+        return ""
+
+    s = text.strip()
+    # Remove leading ```lang and trailing ``` fences
+    if s.startswith("```"):
+        s = re.sub(r"^```\w*\n?", "", s)
+        s = s.rsplit("```", 1)[0].strip()
+
+    # Drop leading "Here is/are ...:" veneer
+    s = re.sub(r"^(here\s+(is|are)[^:]*:\s*)", "", s, flags=re.I)
+    # Remove any stray fenced blocks inside
+    s = s.replace("```", "")
+    return s.strip()
 
 
 def build_html(body: str) -> str:
@@ -6,4 +46,116 @@ def build_html(body: str) -> str:
     return f"<html><body>{body}</body></html>"
 
 
-__all__ = ["build_html"]
+def build_prompt3_html(
+    date_str: str,
+    art: dict,
+    sections: list[Section],
+    final_reflection: str,
+) -> str:
+    """Return a complete HTML document for the Prompt‑3 booklet layout.
+
+    The markup is deterministic and does not depend on LLM‑provided HTML.
+    """
+
+    # Base template with placeholders; fill with escaped values below
+    style = """
+<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\">
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+  <title>Daily Readings – {DATE}</title>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; margin: 0; padding: 0; color: #222; }
+    .page { padding: 24px; max-width: 760px; margin: 0 auto; }
+    .cover { text-align: center; margin-bottom: 24px; }
+    .cover h1 { margin: 0 0 4px; font-size: 28px; }
+    .cover h2 { margin: 0 0 16px; font-weight: 500; font-size: 20px; color: #555; }
+    .figurewrap { margin: 0 auto 8px; }
+    .figurewrap img { max-width: 100%; height: auto; border-radius: 4px; }
+    .caption { font-size: 12px; color: #555; margin-top: 4px; }
+    main.content { margin-top: 12px; }
+    h2 { font-size: 20px; margin: 20px 0 8px; }
+    p { line-height: 1.45; }
+    p.context { color: #333; font-size: 14px; }
+    .reading { white-space: pre-wrap; background: #fafafa; border: 1px solid #eee; padding: 8px 10px; border-radius: 4px; }
+    p.exegesis { font-size: 14px; color: #333; }
+    ul.q-list { margin: 6px 0 14px 20px; }
+    ul.q-list li { margin: 4px 0; }
+    hr { border: 0; border-top: 1px solid #ddd; margin: 18px 0; }
+    section.final-reflect { margin-top: 20px; }
+  </style>
+</head>
+<body>
+  <div class=\"page\">
+    <section class=\"cover\">
+      <h1>Daily Readings</h1>
+      <h2>{DATE}</h2>
+      <div class=\"figurewrap\">
+        <img src=\"{IMG}\" alt=\"Artwork\">
+      </div>
+      <div class=\"caption\">{TITLE}<br>by {ARTIST}, {YEAR}</div>
+    </section>
+    <main class=\"content\">
+"""
+
+    style = (
+        style.replace("{DATE}", html.escape(date_str))
+        .replace("{IMG}", html.escape(art.get("image_url", "")))
+        .replace("{TITLE}", html.escape(art.get("title", "")))
+        .replace("{ARTIST}", html.escape(art.get("artist", "")))
+        .replace("{YEAR}", html.escape(art.get("year", "")))
+    )
+
+    parts: list[str] = [style.lstrip()]
+
+    def needs_rule(h: str) -> bool:
+        key = h.lower()
+        return (
+            key.startswith("responsorial psalm")
+            or key.startswith("sequence")
+            or key.startswith("gospel")
+        )
+
+    for i, sec in enumerate(sections):
+        if i > 0 and needs_rule(sec.heading):
+            parts.append("      <hr>")
+        parts.append(f"      <h2>{html.escape(sec.heading)}</h2>")
+        if sec.context:
+            parts.append(
+                f"      <p class='context'><strong>Context:</strong> {html.escape(strip_code_fences(sec.context))}</p>"
+            )
+        parts.append(
+            f"      <div class='reading'>{html.escape(strip_code_fences(sec.reading))}</div>"
+        )
+        if sec.exegesis:
+            parts.append(
+                f"      <p class='exegesis'><strong>Exegetical&nbsp;Note:</strong> {html.escape(strip_code_fences(sec.exegesis))}</p>"
+            )
+        parts.append("      <p><strong>Reflection&nbsp;Questions:</strong></p>")
+        q_list = sec.questions or []
+        parts.append("      <ul class='q-list'>")
+        for q in q_list:
+            parts.append(f"        <li>{html.escape(strip_code_fences(q))}</li>")
+        parts.append("      </ul>")
+
+    # Final reflection
+    parts.append("      <hr>")
+    parts.append("      <section class='final-reflect'>")
+    parts.append("        <h2>Final Reflection</h2>")
+    parts.append(f"        <div class='reading'>{html.escape(strip_code_fences(final_reflection))}</div>")
+    parts.append("      </section>")
+
+    parts.append(
+        """
+    </main>
+  </div>
+</body>
+</html>
+"""
+    )
+
+    return "\n".join(parts)
+
+
+__all__ = ["build_html", "build_prompt3_html", "strip_code_fences", "Section"]

--- a/src/lectio_plus/parse.py
+++ b/src/lectio_plus/parse.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import re
 from typing import List
+from .html_build import Section as Prompt3Section
 
 
 @dataclass
@@ -122,5 +123,19 @@ __all__ = [
     "Section",
     "extract_sections",
     "build_readings_block",
+    "make_prompt3_sections",
 ]
 
+
+def make_prompt3_sections(readings_html: str, reflection_text: str) -> tuple[List[Prompt3Section], str]:
+    """Build Prompt‑3 sections and return them with the final reflection.
+
+    Uses the extracted USCCB sections for headings and reading bodies. The
+    ``reflection_text`` is returned unchanged; callers may sanitize it further.
+    """
+
+    secs = extract_sections(readings_html)
+    out: List[Prompt3Section] = []
+    for s in secs:
+        out.append(Prompt3Section(heading=s.label, reading=s.text, context=None, exegesis=None, questions=[]))
+    return out, reflection_text

--- a/tests/test_html_page.py
+++ b/tests/test_html_page.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from lectio_plus.html_build import build_prompt3_html, Section, strip_code_fences
+
+
+def test_build_prompt3_html_basic() -> None:
+    art = {
+        "title": "Test Art",
+        "artist": "Anon",
+        "year": "1900",
+        "image_url": "https://upload.wikimedia.org/test.jpg",
+    }
+    sections = [
+        Section(heading="Reading 1", reading="In the beginning...", questions=["What stood out?"]),
+    ]
+    html_doc = build_prompt3_html("2024-05-04", art, sections, "Final reflection")
+    assert html_doc.startswith("<!DOCTYPE html>")
+    assert art["image_url"] in html_doc
+    assert "```" not in html_doc
+
+
+def test_strip_code_fences() -> None:
+    text = "```markdown\nHere is the content:\nHello\n```"
+    assert strip_code_fences(text) == "Hello"
+

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import types
+
+from lectio_plus.app import OpenAILLM, create_app
+
+
+def test_pdf_endpoint_works(monkeypatch) -> None:
+    # Monkeypatch LLM to avoid network
+    outputs = [
+        "reflection",
+        '{"title": "T", "artist": "A", "year": "2000", "image_url": "https://upload.wikimedia.org/x.jpg"}',
+    ]
+
+    def fake_generate(self, model, prompt, temperature=0.2, max_tokens=None):  # noqa: ARG001
+        return outputs.pop(0)
+
+    monkeypatch.setattr(OpenAILLM, "generate", fake_generate)
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:11434/v1")
+    monkeypatch.setenv("OPENAI_API_KEY", "ollama")
+
+    # Provide a fake pdfkit module
+    fake_pdfkit = types.SimpleNamespace()
+
+    def from_string(html: str, out: bool, options=None):  # noqa: ARG001
+        return b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n..."
+
+    fake_pdfkit.from_string = from_string
+    monkeypatch.setitem(sys.modules, "pdfkit", fake_pdfkit)
+
+    app = create_app()
+    client = app.test_client()
+    resp = client.post("/pdf", data={"date": "2024-05-04"})
+    assert resp.status_code == 200
+    assert resp.headers["Content-Type"].startswith("application/pdf")
+    body = resp.get_data()
+    assert body.startswith(b"%PDF") and len(body) > 10


### PR DESCRIPTION
- Build Prompt-3 booklet HTML deterministically in code; no LLM HTML\n- Always show artwork with caption; strip code-fence noise\n- Add /pdf endpoint with pdfkit preferred and WeasyPrint fallback\n- Add Download PDF button on the home page\n- Expand curator JSON parser for lists; add tests for HTML and PDF