### PR TITLE
feat(usccb): live fetch + parser + cached + offline tests; integrate into Prompt-3 HTML/PDF

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Flask
 openai
 pdfkit
 weasyprint
+beautifulsoup4

--- a/src/lectio_plus/scrape.py
+++ b/src/lectio_plus/scrape.py
@@ -1,9 +1,49 @@
-"""Scraping utilities."""
+"""Scraping utilities for USCCB readings with simple caching."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Tuple
+
+import requests  # type: ignore[import-untyped]
+
+from .cache import SimpleCache
+
+_cache = SimpleCache()
+_TTL_SECONDS = 3 * 60 * 60
 
 
-def fetch(url: str) -> str:
-    """Return placeholder data for ``url``."""
-    return f"data from {url}"
+def fetch_usccb(date_str: str) -> Tuple[str, str]:
+    """Fetch USCCB readings HTML for ``date_str`` (YYYY-MM-DD).
+
+    Returns a tuple of ``(html_text, url)``. Results are cached for ~3 hours.
+    """
+
+    yyyymmdd = date_str.replace("-", "")
+    base = os.getenv("USCCB_BASE_URL", "https://bible.usccb.org/bible/readings/")
+    if not base.endswith("/"):
+        base = base + "/"
+    url = f"{base}{yyyymmdd}.cfm"
+
+    now = time.time()
+    cache_key = f"usccb:{yyyymmdd}"
+    cached = _cache.get(cache_key)
+    if isinstance(cached, dict):
+        exp = cached.get("exp")
+        if isinstance(exp, (int, float)) and exp > now and "text" in cached and "url" in cached:
+            return str(cached["text"]), str(cached["url"])
+
+    resp = requests.get(
+        url,
+        headers={"User-Agent": "lectio-plus/1.0"},
+        timeout=(5, 20),
+    )
+    resp.raise_for_status()
+
+    data = {"text": resp.text, "url": url, "exp": now + _TTL_SECONDS}
+    _cache.set(cache_key, data)
+    return resp.text, url
 
 
-__all__ = ["fetch"]
+__all__ = ["fetch_usccb"]

--- a/tests/test_app_end_to_end_offline.py
+++ b/tests/test_app_end_to_end_offline.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from lectio_plus.app import create_app, OpenAILLM
+from lectio_plus import scrape
+
+
+def test_run_offline_uses_fixture(monkeypatch) -> None:
+    html = Path("fixtures/usccb/sample_1.html").read_text(encoding="utf-8")
+
+    def fake_fetch(date_str: str):  # noqa: ARG001
+        return html, "https://bible.usccb.org/bible/readings/20250809.cfm"
+
+    monkeypatch.setattr(scrape, "fetch_usccb", fake_fetch)
+
+    outputs = [
+        "reflection",
+        '{"title": "T", "artist": "A", "year": "2000", "image_url": "https://upload.wikimedia.org/x.jpg"}',
+    ]
+
+    def fake_generate(self, model, prompt, temperature=0.2, max_tokens=None):  # noqa: ARG001
+        return outputs.pop(0)
+
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:11434/v1")
+    monkeypatch.setenv("OPENAI_API_KEY", "ollama")
+    monkeypatch.setattr(OpenAILLM, "generate", fake_generate)
+
+    app = create_app()
+    client = app.test_client()
+    resp = client.post("/run", data={"date": "2025-08-09"})
+    assert resp.status_code == 200
+    assert resp.headers["Content-Type"].startswith("text/html")
+    body = resp.get_data(as_text=True)
+    assert "Deuteronomy 6:4-13" in body
+

--- a/tests/test_app_smoke.py
+++ b/tests/test_app_smoke.py
@@ -6,6 +6,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 import os
 
 from lectio_plus.app import FakeLLM, OpenAILLM, create_app, run
+from lectio_plus import scrape
 
 
 def test_app_run_returns_html() -> None:
@@ -58,6 +59,13 @@ def test_create_app_get_returns_ok() -> None:
 
 
 def test_post_run_injects_metadata(monkeypatch) -> None:
+    # Ensure offline: provide fixture HTML via scrape layer
+    sample_html = Path("fixtures/usccb/sample_1.html").read_text(encoding="utf-8")
+
+    def fake_fetch(date_str: str):  # noqa: ARG001
+        return sample_html, "https://bible.usccb.org/bible/readings/20240504.cfm"
+
+    monkeypatch.setattr(scrape, "fetch_usccb", fake_fetch)
     outputs = [
         "reflection",
         '{"title": "T", "artist": "A", "year": "2000", "image_url": "https://upload.wikimedia.org/x.jpg"}',

--- a/tests/test_parse_usccb.py
+++ b/tests/test_parse_usccb.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from lectio_plus.parse import parse_usccb_html
+
+
+def test_parse_usccb_html_sections() -> None:
+    html = Path("fixtures/usccb/sample_1.html").read_text(encoding="utf-8")
+    sections = parse_usccb_html(html)
+    labels = [s.label for s in sections]
+    assert any(lab.lower().startswith("reading") for lab in labels)
+    assert any(lab.lower().startswith("responsorial psalm") for lab in labels)
+    assert any(lab.lower().startswith("gospel") for lab in labels)
+    # Ensure text is non-empty for key sections
+    for s in sections:
+        if s.label.lower().startswith(("reading", "responsorial psalm", "gospel")):
+            assert s.text

--- a/tests/test_scrape_usccb.py
+++ b/tests/test_scrape_usccb.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import requests
+
+from lectio_plus import scrape
+
+
+class FakeResp:
+    def __init__(self, text: str, url: str = "") -> None:
+        self.text = text
+        self.url = url
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+def test_fetch_usccb_formats_url_and_caches(monkeypatch, tmp_path) -> None:
+    html = Path("fixtures/usccb/sample_1.html").read_text(encoding="utf-8")
+    captured = {}
+
+    def fake_get(url, headers=None, timeout=None):  # noqa: ARG001
+        captured["url"] = url
+        return FakeResp(html, url)
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    # First call hits fake_get
+    text1, url1 = scrape.fetch_usccb("2025-08-09")
+    assert "20250809.cfm" in url1
+    assert text1.startswith("<html")
+    # Second call should use cache and not call fake_get again
+    captured["url"] = None
+    text2, url2 = scrape.fetch_usccb("2025-08-09")
+    assert text2 == text1
+    assert url2 == url1
+    assert captured["url"] is None


### PR DESCRIPTION
- Add scrape.fetch_usccb(date) with SimpleCache (~3h TTL) and UA\n- Add BeautifulSoup-based parse_usccb_html -> Sections; fallback to fixture parser\n- Wire /run and /pdf to live fetch + parsed sections; build Prompt-3 HTML deterministically\n- Add offline tests: scraping URL/TTL, parser minimal, and end-to-end /run\n- Ensure beautifulsoup4 in requirements.txt; script remains fail-fast